### PR TITLE
Fixes ordering of stdout/stderr redirections

### DIFF
--- a/bt.sh
+++ b/bt.sh
@@ -29,7 +29,7 @@ bt_init () {
     touch /tmp/bt.CPU
     if [ -z "$BT_DISABLE_CPUSAMPLE" ]; then
       # need both mpstat and bc for this to work
-      if type mpstat 2>&1 >/dev/null && type bc 2>&1 >/dev/null; then
+      if type mpstat >/dev/null 2>&1 && type bc >/dev/null 2>&1; then
         bash -c "bt_sample_cpu_idle" &
         export BT_CPUSAMPLE_PID=$!
       fi


### PR DESCRIPTION
From the [bash manual](https://www.gnu.org/software/bash/manual/html_node/Redirections.html):

> Note that the order of redirections is significant. For example, the command
>
> ls > dirlist 2>&1
>
> directs both standard output (file descriptor 1) and standard error (file descriptor 2) to the file dirlist, while the command
>
> ls 2>&1 > dirlist
>
> directs only the standard output to file dirlist, because the standard error was made a copy of the standard output before the standard output was redirected to dirlist.

Since we're running in `bash` proper, we could also use `&>/dev/null` to redirect both. I'm happy to make that change if desired.