### PR TITLE
Send yes stderr to /dev/null

### DIFF
--- a/bt.sh
+++ b/bt.sh
@@ -286,11 +286,11 @@ bt_report () {
 
     printf "[ %8ss ] %s%s%s%s%s * %s\n" \
      "$m_time_s_fmt" \
-     "$(yes ' ' | head -n $m_start_col | tr -d '\n')" \
+     "$(yes ' ' 2> /dev/null | head -n $m_start_col | tr -d '\n')" \
      "$m_bar_start" \
-     "$(yes "$m_bar" | head -n $m_num_middle_units | tr -d '\n')" \
+     "$(yes "$m_bar" 2> /dev/null | head -n $m_num_middle_units | tr -d '\n')" \
      "$m_bar_end" \
-     "$(yes ' ' | head -n $m_num_end_units | tr -d '\n')" \
+     "$(yes ' ' 2> /dev/null | head -n $m_num_end_units | tr -d '\n')" \
      "$m_desc"
   done
 


### PR DESCRIPTION
Suppress `yes` stderr to avoid output like this when SIGPIPE isn't being handled:

```
              ▁▁▁▁▁▁▁▁▁▁▁▁▁▆▇▇▇██▇▇▇▇▇▇▇▇▇▇▇▇▇▇▆▆▅▅▄▄▃▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ * CPU Utilization
yes: standard output: Broken pipe
yes: write error
yes: standard output: Broken pipe
yes: write error
yes: standard output: Broken pipe
yes: write error
[  837.302s ] ├─────────────────────────────────────────────────────────────────┤              * all package builds
yes: standard output: Broken pipe
yes: write error
yes: standard output: Broken pipe
yes: write error
yes: standard output: Broken pipe
yes: write error
```