### PR TITLE
Use isolated scratch space

### DIFF
--- a/bt.sh
+++ b/bt.sh
@@ -232,7 +232,7 @@ bt_report () {
   fi
 
   # measurements sorted chronologically by start time
-  for m in $(ls -1 "$BT_DIR"/*.* | sort -t '.' -k3,3 -n); do
+  for m in $(ls -1 "$BT_DIR"/*.* | sort -t '.' -k2,2 -n); do
     local m_failed=0
     local m_desc=$(head -n1 $m | cut -d ' ' -f 2-)
     local m_start_ms=$((${m##*.} / 1000000))


### PR DESCRIPTION
This PR makes it possible to run scripts tracked by BT in parallel with each other.  That has at least two use cases -- running multiple scripts (e.g., test suites) in parallel, and sharing a build server with other people who also use BT.

The prior behavior was to put scratch files in hard-coded names in `/tmp`, like `/tmp/bt.START` and `/tmp/bt.CPU`.  The new behavior is to create a scratch directory with `mktemp` and put all the files in there, like `/tmp/bt-12345-asdfasd/START`.  The scratch directory is exported in the variable `BT_DIR`, so subprocesses know where to find it.

In addition to allowing parallel execution, this is a modest security improvement.  Creating and writing files with predictable names in world-writable directories like `/tmp` allows an attacker with access to the same host to clobber files owned by you.